### PR TITLE
Drop the 5 from the php-fpm naming

### DIFF
--- a/zendserver/init.sls
+++ b/zendserver/init.sls
@@ -30,14 +30,14 @@ nginx:
       - pkg: nginx
       - pkg: zendserver
 
-# Also deal with php5-fpm
-php5-fpm:
+# Also deal with php-fpm
+php-fpm:
   service.running:
     - require:
-      - file: /etc/init.d/php5-fpm
+      - file: /etc/init.d/php-fpm
       - pkg: zendserver
 
-/etc/init.d/php5-fpm:
+/etc/init.d/php-fpm:
   file.symlink:
     - target: /usr/local/zend/bin/php-fpm.sh
 


### PR DESCRIPTION
Along with changes to the [vhosting](https://github.com/Enrise/vhosting-formula/pull/42) and [phpfpm](https://github.com/Enrise/phpfpm-formula/pull/20) formulas, this change drops support for the php5-fpm naming convention.