### PR TITLE
Make compatible with zendserver 2019

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -5,7 +5,7 @@ zendserver:
 
   # Which versions to use for Zend Server & PHP.
   version:
-    zend: '2018.0'
+    zend: '2019.0'
     php: '7.2'
     apache: '2.4'
 

--- a/zendserver/extensions.sls
+++ b/zendserver/extensions.sls
@@ -11,6 +11,8 @@
 # Get the key
 {% set zend_api_key = salt['grains.get']('zendserver:api:key') %}
 
+{% set php_version = salt['pillar.get']('zendserver:version:php', '5.5') %}
+
 # Enable extensions if set
 zendserver.enable_extensions:
  cmd.run:
@@ -28,6 +30,10 @@ zendserver.disable_extensions:
 /usr/local/zend/bin/zs-manage extension-off -e {{ extension_off }} -N admin -K {{ zend_api_key }}; {% endfor -%}
 {% set must_restart_zend = True %}
 {% endif %}
+
+zendserver.changePhpVersion:
+ cmd.run:
+   - name: /etc/zendserver/changePhpVersion.php admin {{ zend_api_key }} {{ php_version }}
 
 # If and extension was changed, we restart as a precaution. Most extensions requre a restart to be activated.
 {% if must_restart_zend %}

--- a/zendserver/files/changePhpVersion.php
+++ b/zendserver/files/changePhpVersion.php
@@ -1,0 +1,41 @@
+#!/usr/bin/env php
+<?php
+
+if ($argc < 4)
+{
+    echo "use like: php changePhpVersion.php user api_key 7.3\n";
+    exit();
+}
+
+$user = $argv[1];
+$apiKey = $argv[2];
+$phpVersion = $argv[3];
+
+function generateRequestSignature($host, $path, $timestamp, $userAgent, $apiKey)
+{
+    $data = $host . ":" .$path. ":" .$userAgent. ":" .gmdate('D, d M Y H:i:s ', $timestamp) . 'GMT';
+    return hash_hmac('sha256', $data, $apiKey);
+}
+
+$host = "localhost:10081";
+$path = "/ZendServer/Api/changePhpVersion";
+$userAgent = "PhpVersionChanger";
+$signature = generateRequestSignature($host, $path, time(), $userAgent, $apiKey);
+
+$ch = curl_init();
+
+curl_setopt($ch, CURLOPT_URL, "http://".$host.$path);
+curl_setopt($ch, CURLOPT_POST, 1);
+curl_setopt($ch, CURLOPT_POSTFIELDS, "phpVersion=".$phpVersion);
+
+$headers = [
+    'Accept: application/vnd.zend.serverapi+json;version=1.16',
+    'User-Agent: '. $userAgent,
+    'Content-Type: application/x-www-form-urlencoded; charset=utf-8',
+    'Date: '.gmdate('D, d M Y H:i:s ').'GMT',
+    'X-Zend-Signature: '. $user.";".$signature,
+];
+
+curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+$server_output = curl_exec($ch);
+curl_close($ch);

--- a/zendserver/init.sls
+++ b/zendserver/init.sls
@@ -70,11 +70,11 @@ apache2-mpm-itk:
 zendserver:
   pkg.installed:
 {%- if webserver == 'nginx' %}
-    - name: zend-server-nginx-php-{{ php_version }}
+    - name: zend-server-nginx
     - require:
       - pkg: nginx
 {%- else %}
-    - name: zend-server-php-{{ php_version }}
+    - name: zend-server-php
 {%- endif %}
 
 # Set alternative to PHP since Zend Server uses a different folder
@@ -125,6 +125,13 @@ alternative-phpize:
 /etc/zendserver/bootstrap-zs.sh:
   file.managed:
     - source: salt://zendserver/files/bootstrap-zs.sh
+    - user: root
+    - group: adm
+    - mode: 740
+
+/etc/zendserver/changePhpVersion.php:
+  file.managed:
+    - source: salt://zendserver/files/changePhpVersion.php
     - user: root
     - group: adm
     - mode: 740

--- a/zendserver/init.sls
+++ b/zendserver/init.sls
@@ -74,7 +74,7 @@ zendserver:
     - require:
       - pkg: nginx
 {%- else %}
-    - name: zend-server-php
+    - name: zend-server-apache-fpm
 {%- endif %}
 
 # Set alternative to PHP since Zend Server uses a different folder


### PR DESCRIPTION
This should make this formula compatible with ZendServer 2019. It also updates the php-version which is since ZendServer 2019 configurable using the UI (and not yet using the zs-manage or client, hence the extra script).